### PR TITLE
WIP: Add INTERBTC and KBTC, fix exports

### DIFF
--- a/src/currencies/bitcoin.ts
+++ b/src/currencies/bitcoin.ts
@@ -8,7 +8,7 @@ const BTCUnit = {
 } as const;
 export type BTCUnit = typeof BTCUnit;
 
-export const Bitcoin: Currency<typeof BTCUnit> = {
+export const BitcoinCurrencyLiteral: Currency<typeof BTCUnit> = {
   name: "Bitcoin",
   base: BTCUnit.BTC,
   rawBase: BTCUnit.Satoshi,
@@ -16,9 +16,9 @@ export const Bitcoin: Currency<typeof BTCUnit> = {
   humanDecimals: 5,
   ticker: "BTC"
 } as const;
-export type Bitcoin = typeof Bitcoin;
+export type Bitcoin = typeof BitcoinCurrencyLiteral;
 
 export class BTCAmount extends MonetaryAmount<Bitcoin, BTCUnit> {
-  static from = generateFromConversions(Bitcoin, BTCUnit);
+  static from = generateFromConversions(BitcoinCurrencyLiteral, BTCUnit);
   static zero = BTCAmount.from.BTC(0);
 }

--- a/src/currencies/ethereum.ts
+++ b/src/currencies/ethereum.ts
@@ -12,25 +12,25 @@ const ETHUnit = {
   Wei: 0,
 } as const;
 export type ETHUnit = typeof ETHUnit;
-export const Ethereum: Currency<typeof ETHUnit> = {
+export const EthereumCurrencyLiteral: Currency<typeof ETHUnit> = {
   name: "Ethereum",
   units: ETHUnit,
   base: ETHUnit.ETH,
   rawBase: ETHUnit.Wei,
   ticker: "ETH"
 } as const;
-export type Ethereum = typeof Ethereum;
+export type Ethereum = typeof EthereumCurrencyLiteral;
 
 /* Example that extends the constructor to allow convenient `new ETHAmount(amount)` calls */
 export class ETHAmount extends MonetaryAmount<Ethereum, ETHUnit> {
   constructor(amount: BigSource, unit?: keyof ETHUnit) {
-    super(Ethereum, amount, unit ? ETHUnit[unit] : 0);
+    super(EthereumCurrencyLiteral, amount, unit ? ETHUnit[unit] : 0);
   }
   withAmount(amount: BigSource): this {
     const Cls = this.constructor as new (amount: BigSource) => this;
     return new Cls(amount);
   }
-  static from = generateFromConversions(Ethereum, ETHUnit);
+  static from = generateFromConversions(EthereumCurrencyLiteral, ETHUnit);
   static zero = ETHAmount.from.ETH(0);
 }
 

--- a/src/currencies/interbtc.ts
+++ b/src/currencies/interbtc.ts
@@ -1,0 +1,13 @@
+import { Currency, generateFromConversions, MonetaryAmount } from "../monetary";
+import { BitcoinCurrencyLiteral, BTCUnit } from "./bitcoin";
+
+export const InterBTCCurrencyLiteral: Currency<BTCUnit> = {
+    ...BitcoinCurrencyLiteral,
+    ticker: "INTERBTC"
+} as const;
+export type InterBTC = typeof InterBTCCurrencyLiteral;
+
+export class InterBTCAmount extends MonetaryAmount<InterBTC, BTCUnit> {
+  static from = generateFromConversions(BitcoinCurrencyLiteral, BitcoinCurrencyLiteral.units);
+  static zero = InterBTCAmount.from.BTC(0);
+}

--- a/src/currencies/kbtc.ts
+++ b/src/currencies/kbtc.ts
@@ -1,0 +1,13 @@
+import { Currency, generateFromConversions, MonetaryAmount } from "../monetary";
+import { BitcoinCurrencyLiteral, BTCUnit } from "./bitcoin";
+
+export const KBTCCurrencyLiteral: Currency<BTCUnit> = {
+    ...BitcoinCurrencyLiteral,
+    ticker: "KBTC"
+} as const;
+export type KBTC = typeof KBTCCurrencyLiteral;
+
+export class KBTCAmount extends MonetaryAmount<KBTC, BTCUnit> {
+  static from = generateFromConversions(BitcoinCurrencyLiteral, BitcoinCurrencyLiteral.units);
+  static zero = KBTCAmount.from.BTC(0);
+}

--- a/src/exchangeRate.ts
+++ b/src/exchangeRate.ts
@@ -1,4 +1,7 @@
 import Big, {RoundingMode} from "big.js";
+import { Bitcoin, BitcoinCurrencyLiteral, BTCUnit } from "./currencies";
+import { InterBTC, InterBTCCurrencyLiteral } from "./currencies/interbtc";
+import { KBTC, KBTCCurrencyLiteral } from "./currencies/kbtc";
 import { Currency, MonetaryAmount, UnitList } from "./monetary";
 
 Big.DP = 100;
@@ -129,3 +132,23 @@ export class ExchangeRate<
     );
   }
 }
+
+const one = new Big(1);
+
+export const BTC_INTERBTC = new ExchangeRate<Bitcoin, BTCUnit, InterBTC, BTCUnit>(
+  BitcoinCurrencyLiteral,
+  InterBTCCurrencyLiteral,
+  one
+);
+
+export const BTC_KBTC = new ExchangeRate<Bitcoin, BTCUnit, KBTC, BTCUnit>(
+  BitcoinCurrencyLiteral,
+  KBTCCurrencyLiteral,
+  one
+);
+
+export const INTERBTC_KBTC = new ExchangeRate<InterBTC, BTCUnit, KBTC, BTCUnit>(
+  InterBTCCurrencyLiteral,
+  KBTCCurrencyLiteral,
+  one
+);

--- a/test/exchangeRate.test.ts
+++ b/test/exchangeRate.test.ts
@@ -2,10 +2,12 @@ import Big from "big.js";
 import { expect } from "chai";
 import {
   Bitcoin,
+  BitcoinCurrencyLiteral,
   BTCAmount,
   BTCUnit,
   ETHAmount,
   Ethereum,
+  EthereumCurrencyLiteral,
   ETHUnit,
 } from "../src/currencies";
 import { ExchangeRate } from "../src/exchangeRate";
@@ -17,17 +19,17 @@ const fcDouble = (): fc.Arbitrary<number> =>
 describe("ExchangeRate", () => {
   const rawRate = new Big(0.05849583145); // ETH/BTC
   const ETHBTCRate = new ExchangeRate<Ethereum, ETHUnit, Bitcoin, BTCUnit>(
-    Ethereum,
-    Bitcoin,
+    EthereumCurrencyLiteral,
+    BitcoinCurrencyLiteral,
     rawRate
   );
   const smallDenominationRawRate = new Big(0.000000000005849583145); // WEI/SAT
   const WEISATRate = new ExchangeRate<Ethereum, ETHUnit, Bitcoin, BTCUnit>(
-    Ethereum,
-    Bitcoin,
+    EthereumCurrencyLiteral,
+    BitcoinCurrencyLiteral,
     smallDenominationRawRate,
-    Ethereum.units.Wei,
-    Bitcoin.units.Satoshi,
+    EthereumCurrencyLiteral.units.Wei,
+    BitcoinCurrencyLiteral.units.Satoshi,
   );
 
   describe("toBase", () => {
@@ -39,8 +41,8 @@ describe("ExchangeRate", () => {
             const ethAmount = ETHBTCRate.toBase(
               BTCAmount.from.BTC(rawRate.mul(amount))
             );
-            expect(ethAmount.toString(Ethereum.base)).to.eq(
-              new Big(amount).round(Ethereum.base).toString()
+            expect(ethAmount.toString(EthereumCurrencyLiteral.base)).to.eq(
+              new Big(amount).round(EthereumCurrencyLiteral.base).toString()
             );
           }
         )
@@ -55,8 +57,8 @@ describe("ExchangeRate", () => {
           fcDouble(),
           (amount) => {
             const btcAmount = ETHBTCRate.toCounter(ETHAmount.from.ETH(amount));
-            expect(btcAmount.toString(Bitcoin.base)).to.eq(
-              rawRate.mul(amount).round(Bitcoin.base).toString()
+            expect(btcAmount.toString(BitcoinCurrencyLiteral.base)).to.eq(
+              rawRate.mul(amount).round(BitcoinCurrencyLiteral.base).toString()
             );
           }
         )
@@ -70,11 +72,11 @@ describe("ExchangeRate", () => {
     });
 
     it("should convert the rate for different currency units", () => {
-      Object.entries(Bitcoin.units).map(([btcUnit, btcDecimals]) => {
-        Object.entries(Ethereum.units).map(([ethUnit, ethDecimals]) => {
+      Object.entries(BitcoinCurrencyLiteral.units).map(([btcUnit, btcDecimals]) => {
+        Object.entries(EthereumCurrencyLiteral.units).map(([ethUnit, ethDecimals]) => {
           const normalisedRate = rawRate
-            .mul(new Big(10).pow(Bitcoin.base - btcDecimals)) // ETH/btcUnit
-            .div(new Big(10).pow(Ethereum.base - ethDecimals)); // ethUnit/btcUnit
+            .mul(new Big(10).pow(BitcoinCurrencyLiteral.base - btcDecimals)) // ETH/btcUnit
+            .div(new Big(10).pow(EthereumCurrencyLiteral.base - ethDecimals)); // ethUnit/btcUnit
           expect(
             ETHBTCRate.toBig({
               baseUnit: ethDecimals,
@@ -92,8 +94,8 @@ describe("ExchangeRate", () => {
   describe("toRawBig", () => {
     it("should return the normalised rate (between smallest currency units)", () => {
       const normalisedRate = rawRate
-        .mul(new Big(10).pow(Bitcoin.base)) // ETH/Sat
-        .div(new Big(10).pow(Ethereum.base)); // Wei/Sat
+        .mul(new Big(10).pow(BitcoinCurrencyLiteral.base)) // ETH/Sat
+        .div(new Big(10).pow(EthereumCurrencyLiteral.base)); // Wei/Sat
       expect(ETHBTCRate.toRawBig().toString()).to.eq(normalisedRate.toString());
     });
   });
@@ -108,11 +110,11 @@ describe("ExchangeRate", () => {
     });
 
     it("should convert the rate for different currency units", () => {
-      Object.entries(Bitcoin.units).map(([btcUnit, btcDecimals]) => {
-        Object.entries(Ethereum.units).map(([ethUnit, ethDecimals]) => {
+      Object.entries(BitcoinCurrencyLiteral.units).map(([btcUnit, btcDecimals]) => {
+        Object.entries(EthereumCurrencyLiteral.units).map(([ethUnit, ethDecimals]) => {
           const normalisedRate = rawRate
-            .mul(new Big(10).pow(Bitcoin.base - btcDecimals)) // ETH/btcUnit
-            .div(new Big(10).pow(Ethereum.base - ethDecimals)); // ethUnit/btcUnit
+            .mul(new Big(10).pow(BitcoinCurrencyLiteral.base - btcDecimals)) // ETH/btcUnit
+            .div(new Big(10).pow(EthereumCurrencyLiteral.base - ethDecimals)); // ethUnit/btcUnit
           expect(
             ETHBTCRate.toString({
               baseUnit: ethDecimals,
@@ -130,8 +132,8 @@ describe("ExchangeRate", () => {
   describe("toRawString", () => {
     it("should return the normalised rate (between smallest currency units)", () => {
       const normalisedRate = rawRate
-        .mul(new Big(10).pow(Bitcoin.base)) // ETH/Sat
-        .div(new Big(10).pow(Ethereum.base)); // Wei/Sat
+        .mul(new Big(10).pow(BitcoinCurrencyLiteral.base)) // ETH/Sat
+        .div(new Big(10).pow(EthereumCurrencyLiteral.base)); // Wei/Sat
       expect(ETHBTCRate.toRawString()).to.eq(normalisedRate.toString());
     });
   });
@@ -139,7 +141,7 @@ describe("ExchangeRate", () => {
   describe("toHuman", () => {
     it("should format with the max decimals of either currency by default", () => {
       const rate = rawRate.round(
-        Math.max(Bitcoin.humanDecimals || 0, Ethereum.humanDecimals || 0)
+        Math.max(BitcoinCurrencyLiteral.humanDecimals || 0, EthereumCurrencyLiteral.humanDecimals || 0)
       );
       expect(ETHBTCRate.toHuman()).to.eq(rate.toString());
     });


### PR DESCRIPTION
There was a naming conflict for exports. Currency definition export the same name twice (e.g. `Bitcoin` the constant and `Bitcoin` the type, which override each other). This PR renames the former to e.g. `BitcoinCurrencyLiteral` to avoid confusion and export overrides.