### PR TITLE
feat: improved rounding in toHuman()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/monetary-js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "build/index.js",
   "description": "JavaScript library to safely handle currency and cryptocurrency amounts",
   "license": "MIT",

--- a/src/currencies/bitcoin.ts
+++ b/src/currencies/bitcoin.ts
@@ -13,7 +13,7 @@ export const Bitcoin: Currency<typeof BitcoinUnit> = {
   base: BitcoinUnit.BTC,
   rawBase: BitcoinUnit.Satoshi,
   units: BitcoinUnit,
-  humanDecimals: 5,
+  humanDecimals: 8,
   ticker: "BTC"
 } as const;
 export type Bitcoin = typeof Bitcoin;

--- a/src/currencies/ethereum.ts
+++ b/src/currencies/ethereum.ts
@@ -17,7 +17,8 @@ export const Ethereum: Currency<typeof EthereumUnit> = {
   units: EthereumUnit,
   base: EthereumUnit.ETH,
   rawBase: EthereumUnit.Wei,
-  ticker: "ETH"
+  ticker: "ETH",
+  humanDecimals: 7
 } as const;
 export type Ethereum = typeof Ethereum;
 

--- a/src/currencies/interlay.ts
+++ b/src/currencies/interlay.ts
@@ -12,7 +12,7 @@ export const Interlay: Currency<InterlayUnit> = {
   base: InterlayUnit.INTR,
   rawBase: InterlayUnit.Planck,
   units: InterlayUnit,
-  humanDecimals: 3,
+  humanDecimals: 5,
   ticker: "INTR"
 } as const;
 export type Interlay = typeof Interlay;

--- a/src/currencies/kintsugi.ts
+++ b/src/currencies/kintsugi.ts
@@ -12,7 +12,7 @@ export const Kintsugi: Currency<KintsugiUnit> = {
   base: KintsugiUnit.KINT,
   rawBase: KintsugiUnit.Planck,
   units: KintsugiUnit,
-  humanDecimals: 3,
+  humanDecimals: 5,
   ticker: "KINT"
 } as const;
 export type Kintsugi = typeof Kintsugi;

--- a/src/currencies/kusama.ts
+++ b/src/currencies/kusama.ts
@@ -12,7 +12,7 @@ export const Kusama: Currency<KusamaUnit> = {
   base: KusamaUnit.KSM,
   rawBase: KusamaUnit.Planck,
   units: KusamaUnit,
-  humanDecimals: 3,
+  humanDecimals: 5,
   ticker: "KSM"
 } as const;
 export type Kusama = typeof Kusama;

--- a/src/currencies/polkadot.ts
+++ b/src/currencies/polkadot.ts
@@ -12,7 +12,7 @@ export const Polkadot: Currency<PolkadotUnit> = {
   base: PolkadotUnit.DOT,
   rawBase: PolkadotUnit.Planck,
   units: PolkadotUnit,
-  humanDecimals: 3,
+  humanDecimals: 5,
   ticker: "DOT"
 } as const;
 export type Polkadot = typeof Polkadot;

--- a/src/monetary.ts
+++ b/src/monetary.ts
@@ -1,6 +1,8 @@
 import Big, { RoundingMode, BigSource } from "big.js";
 
 Big.DP = 100;
+Big.NE = -20;
+Big.PE = 20;
 
 export type UnitList = Record<string, number>;
 
@@ -57,9 +59,14 @@ export class MonetaryAmount<C extends Currency<U>, U extends UnitList> {
   }
 
   toHuman(decimals: number | undefined = this.currency.humanDecimals): string {
-    let big = this.toBig(this.currency.base);
-    if (decimals !== undefined) big = big.round(decimals);
-    return big.toString();
+    const big = this.toBig(this.currency.base);
+    let rounded: string;
+    if (decimals !== undefined) {
+      rounded = big.e >= -decimals ?
+        big.round(decimals).toString() :
+        big.toPrecision(1); // show at least 1 significant digit if rounding would give '0'
+    } else rounded = big.toString();
+    return rounded;
   }
 
   private parseCmpMembers(lhs: this, rhs: this, rm?: RoundingMode): [Big, Big] {

--- a/test/monetary.test.ts
+++ b/test/monetary.test.ts
@@ -8,9 +8,12 @@ import {
   MonetaryAmount,
 } from "../src/monetary";
 
-const fcBig = (): fc.Arbitrary<Big> =>
+const fcBig = ({
+  min,
+  max,
+}: { min?: number; max?: number } = {}): fc.Arbitrary<Big> =>
   fc
-    .double({ next: true, noDefaultInfinity: true, noNaN: true })
+    .double({ next: true, min, max, noDefaultInfinity: true, noNaN: true })
     .map((v) => new Big(v));
 const fcDouble = (): fc.Arbitrary<number> =>
   fc.double({ next: true, noDefaultInfinity: true, noNaN: true });
@@ -86,12 +89,29 @@ describe("MonetaryAmount", () => {
   describe("toHuman", () => {
     it("should format to base unit with default decimals", () => {
       fc.assert(
-        fc.property(fcBig(), (rawAmount) => {
+        fc.property(
+          fcBig().filter(
+            (big) =>
+              big.div(new Big(10).pow(DummyCurrency.base)).e >
+              -(DummyCurrency.humanDecimals || 100)
+          ),
+          (rawAmount) => {
+            const amount = new DummyAmount(rawAmount);
+            const scaled = amount
+              .toBig(DummyCurrency.base)
+              .round(DummyCurrency.humanDecimals)
+              .toString();
+            expect(amount.toHuman()).to.eq(scaled);
+          }
+        )
+      );
+    });
+
+    it("should leave at least 1 significant digit if rounding gives 0", () => {
+      fc.assert(
+        fc.property(fcBig({ min: -0.001, max: 0.001 }), (rawAmount) => {
           const amount = new DummyAmount(rawAmount);
-          const scaled = amount
-            .toBig(DummyCurrency.base)
-            .round(DummyCurrency.humanDecimals)
-            .toString();
+          const scaled = amount.toBig(DummyCurrency.base).toPrecision(1);
           expect(amount.toHuman()).to.eq(scaled);
         })
       );
@@ -104,10 +124,11 @@ describe("MonetaryAmount", () => {
           fc.integer(-1e6, 1e6), // big.js decimal place limits
           (rawAmount, decimals) => {
             const amount = new DummyAmount(rawAmount);
-            const scaled = amount
-              .toBig(DummyCurrency.base)
-              .round(decimals)
-              .toString();
+            const base = amount.toBig(DummyCurrency.base);
+            const scaled =
+              base.e >= -decimals
+                ? base.round(decimals).toString()
+                : base.toPrecision(1);
             expect(amount.toHuman(decimals)).to.eq(scaled);
           }
         )


### PR DESCRIPTION
 - ensured at least 1 significant digit is displayed if rounding would give '0' (to avoid confusing displaying zero values when amount is very small but non-zero)
 - adjusted rounding values for currencies: do not round for Bitcoin (i.e. "round" to 1 sat), round to 5 d.p. for most dotsama-based currencies