### PR TITLE
Fix: increase to string exponent cutoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/monetary-js",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "build/index.js",
   "description": "JavaScript library to safely handle currency and cryptocurrency amounts",
   "license": "MIT",

--- a/src/monetary.ts
+++ b/src/monetary.ts
@@ -1,8 +1,8 @@
 import Big, { RoundingMode, BigSource } from "big.js";
 
 Big.DP = 100;
-Big.NE = -20;
-Big.PE = 20;
+Big.NE = -39;
+Big.PE = 39;
 
 export interface Currency {
   readonly name: string;

--- a/test/monetary.test.ts
+++ b/test/monetary.test.ts
@@ -1,6 +1,7 @@
 import Big, { BigSource, RoundingMode } from "big.js";
 import { expect } from "chai";
 import * as fc from "fast-check";
+import { Polkadot } from "../src/currencies";
 
 import { Currency, MonetaryAmount } from "../src/monetary";
 
@@ -68,6 +69,21 @@ describe("MonetaryAmount", () => {
           );
         })
       );
+    });
+
+    it("should show full amount or scientific notation as expected", () => {
+      // expected cutoff is 39
+      const above = Big(1e39);
+      const below = above.sub(1);
+
+      const amountAbove = new MonetaryAmount(Polkadot, 0).withAtomicAmount(above);
+      const amountBelow = new MonetaryAmount(Polkadot, 0).withAtomicAmount(below);
+
+      expect(amountAbove.toString(true)).to.eq("1e+39");
+
+      // 39 times the '9' character
+      const expectedBelow = "9".repeat(39);
+      expect(amountBelow.toString(true)).to.eq(expectedBelow)
     });
   });
 


### PR DESCRIPTION
Adjust exponent cutoff to avoid monetary returning scientific notation when using `MonetaryAmount.toString(true)` before we reach the maximum that can be stored in `u128`, ie. `log10(2^128) = 38.5`