### PR TITLE
Feat: Export big config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/monetary-js",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "build/index.js",
   "description": "JavaScript library to safely handle currency and cryptocurrency amounts",
   "license": "MIT",

--- a/src/monetary.ts
+++ b/src/monetary.ts
@@ -1,8 +1,12 @@
 import Big, { RoundingMode, BigSource } from "big.js";
 
-Big.DP = 100;
-Big.NE = -39;
-Big.PE = 39;
+export function configGlobalBig(): void {
+  Big.DP = 100;
+  Big.NE = -39;
+  Big.PE = 39;  
+}
+
+configGlobalBig();
 
 export interface Currency {
   readonly name: string;


### PR DESCRIPTION
Provides a new method to call that sets the global big.js configuration used in monetary explicitly. 
eg. When the UI wants to use the same big DP/NE/PE values for Big.