### PR TITLE
fix: patch isZero check for lower than smallest unit checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/monetary-js",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "build/index.js",
   "description": "JavaScript library to safely handle currency and cryptocurrency amounts",
   "license": "MIT",

--- a/src/monetary.ts
+++ b/src/monetary.ts
@@ -3,7 +3,7 @@ import Big, { RoundingMode, BigSource } from "big.js";
 export function configGlobalBig(): void {
   Big.DP = 100;
   Big.NE = -39;
-  Big.PE = 39;  
+  Big.PE = 39;
 }
 
 configGlobalBig();
@@ -120,7 +120,7 @@ export class MonetaryAmount<C extends Currency> {
   }
 
   isZero(): boolean {
-    return this._amount.eq(new Big(0));
+    return this.toBig().eq(new Big(0));
   }
 
   protected isSameCurrency(amount: this): boolean {

--- a/test/monetary.test.ts
+++ b/test/monetary.test.ts
@@ -76,14 +76,18 @@ describe("MonetaryAmount", () => {
       const above = Big(1e39);
       const below = above.sub(1);
 
-      const amountAbove = new MonetaryAmount(Polkadot, 0).withAtomicAmount(above);
-      const amountBelow = new MonetaryAmount(Polkadot, 0).withAtomicAmount(below);
+      const amountAbove = new MonetaryAmount(Polkadot, 0).withAtomicAmount(
+        above
+      );
+      const amountBelow = new MonetaryAmount(Polkadot, 0).withAtomicAmount(
+        below
+      );
 
       expect(amountAbove.toString(true)).to.eq("1e+39");
 
       // 39 times the '9' character
       const expectedBelow = "9".repeat(39);
-      expect(amountBelow.toString(true)).to.eq(expectedBelow)
+      expect(amountBelow.toString(true)).to.eq(expectedBelow);
     });
   });
 
@@ -295,6 +299,17 @@ describe("MonetaryAmount", () => {
       it("should fail when dividing by zero", () => {
         expect(() => new DummyAmount(1).div(0)).to.throw("Division by zero");
       });
+    });
+  });
+
+  describe("isZero", () => {
+    it("should be equal to zero if amount is lower than lowest possible unit of currency", () => {
+      const smallestAmount = Big(1).div(10 ** DummyCurrency.decimals);
+      const smallerThanSmallestUnitAmount = smallestAmount.div(10);
+
+      expect(new DummyAmount(smallestAmount).isZero()).to.be.false;
+      expect(new DummyAmount(smallerThanSmallestUnitAmount).isZero()).to.be
+        .true;
     });
   });
 });


### PR DESCRIPTION
Fixing `isZero` check that was returning false for amounts that should be equal to 0, because they are smaller than smallest unit of the currency. Closes #32 