### PR TITLE
Feat: add static constructor method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/monetary-js",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "build/index.js",
   "description": "JavaScript library to safely handle currency and cryptocurrency amounts",
   "license": "MIT",

--- a/src/monetary.ts
+++ b/src/monetary.ts
@@ -144,6 +144,11 @@ export class MonetaryAmount<C extends Currency> {
   }
 
   // NOTE: needs override if constructor is overriden
+  /**
+   * Creates a new MonetaryAmount instance with the same currency, but the given base amount set.
+   * @param amount The base amount in the natural denomination for the currency of this instance.
+   * @returns A new MonetaryAmount instance with the given amount.
+   */
   withAmount(amount: BigSource): this {
     const Cls = this.constructor as new (
       currency: Currency,
@@ -153,10 +158,28 @@ export class MonetaryAmount<C extends Currency> {
   }
 
   // NOTE: may need override if withAmount signature is overriden
+  /**
+   * Creates a new MonetaryAmount instance with the same currency, but with the given atomic amount.
+   * @param amount The atomic amount for the given currency (ie. in its smallest denomination).
+   * @returns A new MonetaryAmount instance with the given atomic amount.
+   */
   withAtomicAmount(amount: BigSource): this {
     const baseAmount = new Big(amount).div(
       new Big(10).pow(this.currency.decimals)
     );
     return this.withAmount(baseAmount);
+  }
+
+  /**
+   * Creates a new MonetaryAmount instance by passing in an atomic amount and the currency type.
+   * @param atomicAmount The atomic amount for the given Currency (ie. in its smallest denomination).
+   * @param currency The currency.
+   * @returns A MonetaryAmount instance for the given currency and amount.
+   */
+  public static fromAtomicAmount<C extends Currency>(atomicAmount: BigSource, currency: C): MonetaryAmount<C> {
+    const baseAmount = Big(atomicAmount).div(
+      Big(10).pow(currency.decimals)
+    );
+    return new this(currency, baseAmount);
   }
 }

--- a/test/monetary.test.ts
+++ b/test/monetary.test.ts
@@ -1,7 +1,7 @@
 import Big, { BigSource, RoundingMode } from "big.js";
 import { expect } from "chai";
 import * as fc from "fast-check";
-import { Polkadot } from "../src/currencies";
+import { Polkadot, PolkadotAmount } from "../src/currencies";
 
 import { Currency, MonetaryAmount } from "../src/monetary";
 
@@ -310,6 +310,21 @@ describe("MonetaryAmount", () => {
       expect(new DummyAmount(smallestAmount).isZero()).to.be.false;
       expect(new DummyAmount(smallerThanSmallestUnitAmount).isZero()).to.be
         .true;
+    });
+  });
+
+  describe("fromAtomicAmount", () => {
+    it("should construct as expected", () => {
+      const expectedNaturalAmount: number = 42;
+      const expectedAtomicAmount: number = expectedNaturalAmount * (10 ** Polkadot.decimals);
+
+      const dotAmount = MonetaryAmount.fromAtomicAmount(expectedAtomicAmount, Polkadot);
+
+      expect(dotAmount.toBig().toNumber()).to.equal(expectedNaturalAmount);
+      expect(dotAmount.toBig(0).toNumber()).to.equal(expectedAtomicAmount);
+
+      const otherDotAmount = new PolkadotAmount(expectedNaturalAmount);
+      expect(dotAmount.toHuman()).to.equal(otherDotAmount.toHuman());
     });
   });
 });


### PR DESCRIPTION
Added static helper method to construct a `MonetaryAmount` instance with atomic amounts.
Added JSDocs for some similar existing methods.